### PR TITLE
Add unpkg to list of CDNs

### DIFF
--- a/hljs_org/settings.py
+++ b/hljs_org/settings.py
@@ -172,4 +172,9 @@ HLJS_CDNS = [
         '//cdn.jsdelivr.net/gh/highlightjs/cdn-release@%s/build/highlight.min.js',
         '//cdn.jsdelivr.net/gh/highlightjs/cdn-release@%s/build/styles/default.min.css',
     ),
+    (
+        'unpkg',
+        '//unpkg.com/@highlightjs/cdn-assets@%s/highlight.min.js',
+        '//unpkg.com/@highlightjs/cdn-assets@%s/styles/default.min.css',
+    ),
 ]


### PR DESCRIPTION
Aligning the list of CDNs on the [download](https://highlightjs.org/download) and [usage](https://highlightjs.org/usage) pages.