### PR TITLE
Fix contrast of comments

### DIFF
--- a/hljs_org/static/code.css
+++ b/hljs_org/static/code.css
@@ -22,5 +22,5 @@ pre {
 }
 
 .hljs-comment {
-    color: #766;
+    color: #938a8a;
 }


### PR DESCRIPTION
Comments in code samples on the [usage page](https://highlightjs.org/usage/) don't have enough contrast:
![image](https://user-images.githubusercontent.com/2564094/138576923-71642f66-46d7-4610-8ed9-7b86e7e4966e.png)
![image](https://user-images.githubusercontent.com/2564094/138576856-7ff2c825-b1e1-40c2-b534-86a4dfad628e.png)

This PR changes the color to `#938a8a` to increase contrast:
![image](https://user-images.githubusercontent.com/2564094/138576916-4332870d-439b-4ddc-9450-849288a88c85.png)
![image](https://user-images.githubusercontent.com/2564094/138576868-03354881-f158-4fda-ac50-35643c53eef4.png)
