### PR TITLE
Fix overflowing in documentation

### DIFF
--- a/hljs_org/static/code.css
+++ b/hljs_org/static/code.css
@@ -8,6 +8,7 @@ pre {
   border-width: 1px;
   border-style: solid;
   border-color: #400 #700 #700 #400;
+  overflow: auto;
 }
 
 .hljs-keyword,


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/10339043/144511845-651ee87e-39dc-4f99-a56c-132b2683bac9.png)
After:
![image](https://user-images.githubusercontent.com/10339043/144511872-fc663bfc-464f-4606-87d0-8f90b8a12551.png)
