### PR TITLE
Adding HTTPS protocol to CDN's URL

### DIFF
--- a/hljs_org/settings.py
+++ b/hljs_org/settings.py
@@ -165,17 +165,17 @@ HLJS_SNIPPETS = [
 HLJS_CDNS = [
     (
         'cdnjs',
-        '//cdnjs.cloudflare.com/ajax/libs/highlight.js/%s/highlight.min.js',
-        '//cdnjs.cloudflare.com/ajax/libs/highlight.js/%s/styles/default.min.css',
+        'https://cdnjs.cloudflare.com/ajax/libs/highlight.js/%s/highlight.min.js',
+        'https://cdnjs.cloudflare.com/ajax/libs/highlight.js/%s/styles/default.min.css',
     ),
     (
         'jsdelivr',
-        '//cdn.jsdelivr.net/gh/highlightjs/cdn-release@%s/build/highlight.min.js',
-        '//cdn.jsdelivr.net/gh/highlightjs/cdn-release@%s/build/styles/default.min.css',
+        'https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@%s/build/highlight.min.js',
+        'https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@%s/build/styles/default.min.css',
     ),
     (
         'unpkg',
-        '//unpkg.com/@highlightjs/cdn-assets@%s/highlight.min.js',
-        '//unpkg.com/@highlightjs/cdn-assets@%s/styles/default.min.css',
+        'https://unpkg.com/@highlightjs/cdn-assets@%s/highlight.min.js',
+        'https://unpkg.com/@highlightjs/cdn-assets@%s/styles/default.min.css',
     ),
 ]


### PR DESCRIPTION
Hello, I've see this issue when a tried to copy and paste the html code for import a the highlightjs from a cdn to my project

![image](https://user-images.githubusercontent.com/27559775/196039698-1c469f8b-4f4a-4822-a0ee-a356e324439a.png)
As you can see on the [download page](https://highlightjs.org/download/) the sources (`src`) are only whit `//....` whitout a protocol, i think the correct is set a protocol or don't put `//`, because only `//` doens't work. Since all thesse CDNs support https protocol, I'm make this PR for insert these protocols.

I've never used django before, I hope this work :)